### PR TITLE
Unity 4.0.1 Support

### DIFF
--- a/src/Nancy.Bootstrappers.Unity.MSBuild/Nancy.Bootstrappers.Unity.csproj
+++ b/src/Nancy.Bootstrappers.Unity.MSBuild/Nancy.Bootstrappers.Unity.csproj
@@ -34,16 +34,20 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Practices.ServiceLocation, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\CommonServiceLocator.1.0\lib\NET35\Microsoft.Practices.ServiceLocation.dll</HintPath>
+    <Reference Include="Microsoft.Practices.ServiceLocation, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\CommonServiceLocator.1.3\lib\portable-net4+sl5+netcore45+wpa81+wp8\Microsoft.Practices.ServiceLocation.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Practices.Unity, Version=2.1.505.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Unity.2.1.505.2\lib\NET35\Microsoft.Practices.Unity.dll</HintPath>
+    <Reference Include="Microsoft.Practices.Unity, Version=4.0.0.0, Culture=neutral, PublicKeyToken=6d32ff45e0ccc69f, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Unity.4.0.1\lib\net45\Microsoft.Practices.Unity.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Practices.Unity.Configuration, Version=2.1.505.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Unity.2.1.505.2\lib\NET35\Microsoft.Practices.Unity.Configuration.dll</HintPath>
+    <Reference Include="Microsoft.Practices.Unity.Configuration, Version=4.0.0.0, Culture=neutral, PublicKeyToken=6d32ff45e0ccc69f, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Unity.4.0.1\lib\net45\Microsoft.Practices.Unity.Configuration.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Practices.Unity.RegistrationByConvention, Version=4.0.0.0, Culture=neutral, PublicKeyToken=6d32ff45e0ccc69f, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Unity.4.0.1\lib\net45\Microsoft.Practices.Unity.RegistrationByConvention.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Nancy.Bootstrappers.Unity.MSBuild/packages.config
+++ b/src/Nancy.Bootstrappers.Unity.MSBuild/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CommonServiceLocator" version="1.0" targetFramework="net45" />
-  <package id="Unity" version="2.1.505.2" targetFramework="net45" />
+  <package id="CommonServiceLocator" version="1.3" targetFramework="net45" />
+  <package id="Unity" version="4.0.1" targetFramework="net45" />
 </packages>

--- a/src/Nancy.Bootstrappers.Unity/nancy.bootstrappers.unity.nuspec
+++ b/src/Nancy.Bootstrappers.Unity/nancy.bootstrappers.unity.nuspec
@@ -14,7 +14,7 @@
     <projectUrl>http://nancyfx.org</projectUrl>
 	  <dependencies>
       <dependency id="Nancy" />
-      <dependency id="Unity" version="2.1.505.2" />
+      <dependency id="Unity" version="4.0.1" />
     </dependencies>
     <tags>Nancy Unity</tags>
   </metadata>

--- a/src/Nancy.Bootstrappers.Unity/project.json
+++ b/src/Nancy.Bootstrappers.Unity/project.json
@@ -12,10 +12,14 @@
 
     "dependencies": {
         "Nancy": { "target": "project" },
-        "Unity": "2.1.505.2"
+        "Unity": "4.0.1"
     },
 
     "frameworks": {
-        "net452": { }
+      "net452": {
+        "frameworkAssemblies": {
+          "System.Runtime": { "type": "build" }
+        }
+      }
     }
 }

--- a/test/Nancy.Bootstrappers.Unity.Tests.MSBuild/Nancy.Bootstrappers.Unity.Tests.csproj
+++ b/test/Nancy.Bootstrappers.Unity.Tests.MSBuild/Nancy.Bootstrappers.Unity.Tests.csproj
@@ -35,16 +35,20 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Practices.ServiceLocation, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\CommonServiceLocator.1.0\lib\NET35\Microsoft.Practices.ServiceLocation.dll</HintPath>
+    <Reference Include="Microsoft.Practices.ServiceLocation, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\CommonServiceLocator.1.3\lib\portable-net4+sl5+netcore45+wpa81+wp8\Microsoft.Practices.ServiceLocation.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Practices.Unity, Version=2.1.505.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Unity.2.1.505.2\lib\NET35\Microsoft.Practices.Unity.dll</HintPath>
+    <Reference Include="Microsoft.Practices.Unity, Version=4.0.0.0, Culture=neutral, PublicKeyToken=6d32ff45e0ccc69f, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Unity.4.0.1\lib\net45\Microsoft.Practices.Unity.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Practices.Unity.Configuration, Version=2.1.505.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Unity.2.1.505.2\lib\NET35\Microsoft.Practices.Unity.Configuration.dll</HintPath>
+    <Reference Include="Microsoft.Practices.Unity.Configuration, Version=4.0.0.0, Culture=neutral, PublicKeyToken=6d32ff45e0ccc69f, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Unity.4.0.1\lib\net45\Microsoft.Practices.Unity.Configuration.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Practices.Unity.RegistrationByConvention, Version=4.0.0.0, Culture=neutral, PublicKeyToken=6d32ff45e0ccc69f, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Unity.4.0.1\lib\net45\Microsoft.Practices.Unity.RegistrationByConvention.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/test/Nancy.Bootstrappers.Unity.Tests.MSBuild/packages.config
+++ b/test/Nancy.Bootstrappers.Unity.Tests.MSBuild/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CommonServiceLocator" version="1.0" targetFramework="net45" />
-  <package id="Unity" version="2.1.505.2" targetFramework="net45" />
+  <package id="CommonServiceLocator" version="1.3" targetFramework="net45" />
+  <package id="Unity" version="4.0.1" targetFramework="net45" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net45" />

--- a/test/Nancy.Bootstrappers.Unity.Tests/project.json
+++ b/test/Nancy.Bootstrappers.Unity.Tests/project.json
@@ -9,13 +9,13 @@
     },
 
     "dependencies": {
-        "CommonServiceLocator": "1.0",
-        "dotnet-test-xunit": "1.0.0-rc3-build10019",
-        "Microsoft.NETCore.Platforms": "1.0.1-rc2-24027",
+        "CommonServiceLocator": "1.3.0",
+        "dotnet-test-xunit": "2.2.0-preview2-build1029",
+        "Microsoft.NETCore.Platforms": "1.0.1",
         "Nancy": { "target": "project" },
         "Nancy.Bootstrappers.Unity": { "target": "project" },
-        "Unity": "2.1.505.2",
-        "xunit": "2.1.0"
+        "Unity": "4.0.1",
+        "xunit": "2.2.0-beta2-build3300"
     },
 
     "frameworks": {


### PR DESCRIPTION
Seeing some guys mention this on the slack group and as an issue (https://github.com/NancyFx/Nancy.Bootstrappers.Unity/issues/23), I wanted to give this one a try and updated `project.json` references to support unity 4.0.1

Builds and all unit tests pass.

I tested it on a sample bare (Nancy 2.0.0-alpha) project and it seems to work. If anyone else wants to try, here is the feed:

https://www.myget.org/F/mengu/api/v3/index.json

Let me know what you think.
