### PR TITLE
Update to Unity 5.11.4

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,18 +39,18 @@ public class Bootstrapper : UnityNancyBootstrapper
 
 You can also override the `GetApplicationContainer` method and return a pre-existing container instance, instead of having Nancy create one for you. This is useful if Nancy is co-existing with another application and you want them to share a single container.
 
+It is recommended that a child container of the application's main container is used so that if the application stops and restarts Nancy, the main container is not disposed of.
+
 ```c#
 protected override IUnityContainer GetApplicationContainer()
 {
     // Return application container instance
+	return parentContainer.CreateChildContainer();
 }
 ```
 
-If you end up overriding `GetApplicationContainer()`, you will have to manually add the `EnumerableExtension` to your container so that it is able to resolve `IEnumerable<T>` types properly (something that Unity has poor support for).
-
-```c#
-container.AddNewExtension<EnumerableExtension>();
-```
+## Changes
+V2.0.0 supports Unity 5.11.4
 
 ## Code of Conduct
 

--- a/src/Nancy.Bootstrappers.Unity/EnumerableExtension.cs
+++ b/src/Nancy.Bootstrappers.Unity/EnumerableExtension.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.Practices.Unity;
-using Microsoft.Practices.Unity.ObjectBuilder;
+﻿using Unity.Builder;
+using Unity.Extension;
 
 namespace Nancy.Bootstrappers.Unity
 {
@@ -8,8 +8,7 @@ namespace Nancy.Bootstrappers.Unity
         protected override void Initialize()
         {
             // Enumerable strategy
-            Context.Strategies.AddNew<EnumerableResolutionStrategy>(
-                UnityBuildStage.TypeMapping);
+            Context.Strategies.Add(new EnumerableResolutionStrategy(), UnityBuildStage.TypeMapping);
         }
     }
 }

--- a/src/Nancy.Bootstrappers.Unity/Nancy.Bootstrappers.Unity.csproj
+++ b/src/Nancy.Bootstrappers.Unity/Nancy.Bootstrappers.Unity.csproj
@@ -4,12 +4,12 @@
     <Authors>Andreas Håkansson, Steven Robbins and contributors</Authors>
     <CodeAnalysisRuleSet>..\..\dependencies\Nancy\Nancy.ruleset</CodeAnalysisRuleSet>
     <Description>An Unity bootstrapper for the Nancy web framework.</Description>
-    <DisableImplicitFrameworkReferences Condition=" '$(TargetFramework)' == 'net452' ">true</DisableImplicitFrameworkReferences>
+    <DisableImplicitFrameworkReferences Condition=" '$(TargetFramework)' == 'net472' ">true</DisableImplicitFrameworkReferences>
     <PackageIconUrl>http://nancyfx.org/nancy-nuget.png</PackageIconUrl>
     <PackageLicenseUrl>https://github.com/NancyFx/Nancy/blob/master/license.txt</PackageLicenseUrl>
     <PackageProjectUrl>http://nancyfx.org</PackageProjectUrl>
     <PackageTags>Nancy;Unity</PackageTags>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <Version>2.0.0-clinteastwood</Version>
   </PropertyGroup>
 
@@ -18,10 +18,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Unity" Version="2.1.505.2" />
+    <PackageReference Include="Unity" Version="5.11.4" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
   </ItemGroup>

--- a/src/Nancy.Bootstrappers.Unity/UnityNancyBootstrapper.cs
+++ b/src/Nancy.Bootstrappers.Unity/UnityNancyBootstrapper.cs
@@ -3,18 +3,21 @@ namespace Nancy.Bootstrappers.Unity
     using System;
     using System.Collections.Generic;
     using Diagnostics;
-    using Microsoft.Practices.Unity;
-    using Nancy.Configuration;
+    using Configuration;
     using Bootstrapper;
+    using global::Unity;
+    using global::Unity.Lifetime;
     using ViewEngines;
 
     /// <summary>
     /// Nancy bootstrapper for the Unity container.
     /// </summary>
-    public abstract class UnityNancyBootstrapper : NancyBootstrapperWithRequestContainerBase<IUnityContainer>
+    public abstract class UnityNancyBootstrapper : NancyBootstrapperWithRequestContainerBase<IUnityContainer>, IDisposable
     {
+        private bool isDisposing = false;
+
         /// <summary>
-        /// Gets the diagnostics for intialisation
+        /// Gets the diagnostics for initialisation
         /// </summary>
         /// <returns>An <see cref="IDiagnostics"/> implementation</returns>
         protected override IDiagnostics GetDiagnostics()
@@ -250,16 +253,25 @@ namespace Nancy.Bootstrappers.Unity
         }
 
         /// <summary>
-        /// Retreive a specific module instance from the container
+        /// Retrieve a specific module instance from the container
         /// </summary>
         /// <param name="container">Container to use</param>
         /// <param name="moduleType">Type of the module</param>
         /// <returns>An <see cref="INancyModule"/> instance</returns>
         protected override INancyModule GetModule(IUnityContainer container, Type moduleType)
         {
-            container.RegisterType(typeof(INancyModule), moduleType, new ContainerControlledLifetimeManager());
+            return container.Resolve(moduleType) as INancyModule;
+        }
 
-            return container.Resolve<INancyModule>();
+        public new void Dispose()
+        {
+            if (this.isDisposing)
+            {
+                return;
+            }
+
+            this.isDisposing = true;
+            base.Dispose();
         }
     }
 }

--- a/test/Nancy.Bootstrappers.Unity.Tests/Nancy.Bootstrappers.Unity.Tests.csproj
+++ b/test/Nancy.Bootstrappers.Unity.Tests/Nancy.Bootstrappers.Unity.Tests.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <CodeAnalysisRuleSet>..\..\dependencies\Nancy\Nancy.ruleset</CodeAnalysisRuleSet>
-    <DisableImplicitFrameworkReferences Condition=" '$(TargetFramework)' == 'net452' ">true</DisableImplicitFrameworkReferences>
-    <TargetFramework>net452</TargetFramework>
+    <DisableImplicitFrameworkReferences Condition=" '$(TargetFramework)' == 'net472' ">true</DisableImplicitFrameworkReferences>
+    <TargetFramework>net472</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -20,14 +20,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommonServiceLocator" Version="1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="Unity" Version="2.1.505.2" />
-    <PackageReference Include="xunit" Version="2.3.0-beta2-build3683" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta2-build1317" />
+    <PackageReference Include="CommonServiceLocator" Version="2.0.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Unity" Version="5.11.4" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Runtime" />
     <Reference Include="System" />


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy.Bootstrappers.Unity/pulls) open
- [x] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
The NancyFx Unity Bootstrapper has been updated to work with Unity version 5.11.4.
<!-- Thanks for contributing to Nancy! -->
